### PR TITLE
Fix 5 correctness bugs: missing SQL columns, stale Win32 error, CLI validation, PSBoundParameters

### DIFF
--- a/src/Servy.CLI/Servy.psm1
+++ b/src/Servy.CLI/Servy.psm1
@@ -1070,7 +1070,8 @@ param(
 
   # 2. Iterate through pairs to build arguments
   foreach ($pair in $paramPairs) {
-    $paramName = $pair[0].TrimStart('-')
+    $camelName = $pair[0].TrimStart('-')
+    $paramName = $camelName.Substring(0,1).ToUpper() + $camelName.Substring(1)
 
     $hasValue = $false
 

--- a/src/Servy.CLI/Validators/ServiceInstallValidator.cs
+++ b/src/Servy.CLI/Validators/ServiceInstallValidator.cs
@@ -87,6 +87,7 @@ namespace Servy.CLI.Validators
             }
 
             if ((opts.EnableRotation || opts.EnableSizeRotation)
+                && !string.IsNullOrWhiteSpace(opts.RotationSize)
                 && (!int.TryParse(opts.RotationSize, out var rotation) || rotation < AppConfig.MinRotationSize || rotation > AppConfig.MaxRotationSize))
             {
                 return CommandResult.Fail(Strings.Msg_InvalidRotationSize);
@@ -111,7 +112,8 @@ namespace Servy.CLI.Validators
                 if (!ValidateEnumOption<RecoveryAction>(opts.RecoveryAction))
                     return CommandResult.Fail(Strings.Msg_InvalidRecoveryAction);
 
-                if (!int.TryParse(opts.MaxRestartAttempts, out var restart) || restart < AppConfig.MinMaxRestartAttempts || restart > AppConfig.MaxMaxRestartAttempts)
+                if (!string.IsNullOrWhiteSpace(opts.MaxRestartAttempts)
+                    && (!int.TryParse(opts.MaxRestartAttempts, out var restart) || restart < AppConfig.MinMaxRestartAttempts || restart > AppConfig.MaxMaxRestartAttempts))
                     return CommandResult.Fail(Strings.Msg_InvalidMaxRestartAttempts);
             }
 

--- a/src/Servy.Core/Services/ServiceManager.cs
+++ b/src/Servy.Core/Services/ServiceManager.cs
@@ -363,6 +363,8 @@ namespace Servy.Core.Services
                     lpPassword: lpPassword
                 );
 
+                int createServiceError = Marshal.GetLastWin32Error();
+
                 // Persist service in database
                 var dto = new ServiceDto
                 {
@@ -527,8 +529,7 @@ namespace Servy.Core.Services
                         return OperationResult.Success();
                     }
 
-                    int error = Marshal.GetLastWin32Error();
-                    string creationErrorMsg = $"Failed to create service '{options.ServiceName}'. Win32 error: {error}";
+                    string creationErrorMsg = $"Failed to create service '{options.ServiceName}'. Win32 error: {createServiceError}";
                     Logger.Error(creationErrorMsg);
                     return OperationResult.Failure(creationErrorMsg);
                 }

--- a/src/Servy.Infrastructure/Data/ServiceRepository.cs
+++ b/src/Servy.Infrastructure/Data/ServiceRepository.cs
@@ -70,19 +70,21 @@ namespace Servy.Infrastructure.Data
                     PostLaunchExecutablePath, PostLaunchStartupDirectory, PostLaunchParameters, Pid, EnableDebugLogs, DisplayName, MaxRotations,
                     EnableDateRotation, DateRotationType, StartTimeout, StopTimeout,
                     PreStopExecutablePath, PreStopStartupDirectory, PreStopParameters, PreStopTimeoutSeconds, PreStopLogAsError,
-                    PostStopExecutablePath, PostStopStartupDirectory, PostStopParameters, UseLocalTimeForRotation
+                    PostStopExecutablePath, PostStopStartupDirectory, PostStopParameters, UseLocalTimeForRotation,
+                    PreviousStopTimeout, ActiveStdoutPath, ActiveStderrPath
                 ) VALUES (
-                    @Name, @Description, @ExecutablePath, @StartupDirectory, @Parameters, 
-                    @StartupType, @Priority, @StdoutPath, @StderrPath, @EnableRotation, @RotationSize, 
-                    @EnableHealthMonitoring, @HeartbeatInterval, @MaxFailedChecks, @RecoveryAction, @MaxRestartAttempts, 
-                    @EnvironmentVariables, @ServiceDependencies, @RunAsLocalSystem, @UserAccount, @Password, 
-                    @PreLaunchExecutablePath, @PreLaunchStartupDirectory, @PreLaunchParameters, @PreLaunchEnvironmentVariables, 
+                    @Name, @Description, @ExecutablePath, @StartupDirectory, @Parameters,
+                    @StartupType, @Priority, @StdoutPath, @StderrPath, @EnableRotation, @RotationSize,
+                    @EnableHealthMonitoring, @HeartbeatInterval, @MaxFailedChecks, @RecoveryAction, @MaxRestartAttempts,
+                    @EnvironmentVariables, @ServiceDependencies, @RunAsLocalSystem, @UserAccount, @Password,
+                    @PreLaunchExecutablePath, @PreLaunchStartupDirectory, @PreLaunchParameters, @PreLaunchEnvironmentVariables,
                     @PreLaunchStdoutPath, @PreLaunchStderrPath, @PreLaunchTimeoutSeconds, @PreLaunchRetryAttempts, @PreLaunchIgnoreFailure,
                     @FailureProgramPath, @FailureProgramStartupDirectory, @FailureProgramParameters,
                     @PostLaunchExecutablePath, @PostLaunchStartupDirectory, @PostLaunchParameters, @Pid, @EnableDebugLogs, @DisplayName, @MaxRotations,
                     @EnableDateRotation, @DateRotationType, @StartTimeout, @StopTimeout,
                     @PreStopExecutablePath, @PreStopStartupDirectory, @PreStopParameters, @PreStopTimeoutSeconds, @PreStopLogAsError,
-                    @PostStopExecutablePath, @PostStopStartupDirectory, @PostStopParameters, @UseLocalTimeForRotation
+                    @PostStopExecutablePath, @PostStopStartupDirectory, @PostStopParameters, @UseLocalTimeForRotation,
+                    @PreviousStopTimeout, @ActiveStdoutPath, @ActiveStderrPath
                 );
                 SELECT last_insert_rowid();";
 
@@ -377,19 +379,21 @@ namespace Servy.Infrastructure.Data
                     PostLaunchExecutablePath, PostLaunchStartupDirectory, PostLaunchParameters, Pid, EnableDebugLogs, DisplayName, MaxRotations,
                     EnableDateRotation, DateRotationType, StartTimeout, StopTimeout,
                     PreStopExecutablePath, PreStopStartupDirectory, PreStopParameters, PreStopTimeoutSeconds, PreStopLogAsError,
-                    PostStopExecutablePath, PostStopStartupDirectory, PostStopParameters, UseLocalTimeForRotation
+                    PostStopExecutablePath, PostStopStartupDirectory, PostStopParameters, UseLocalTimeForRotation,
+                    PreviousStopTimeout, ActiveStdoutPath, ActiveStderrPath
                 ) VALUES (
-                    @Name, @Description, @ExecutablePath, @StartupDirectory, @Parameters, 
-                    @StartupType, @Priority, @StdoutPath, @StderrPath, @EnableRotation, @RotationSize, 
-                    @EnableHealthMonitoring, @HeartbeatInterval, @MaxFailedChecks, @RecoveryAction, @MaxRestartAttempts, 
-                    @EnvironmentVariables, @ServiceDependencies, @RunAsLocalSystem, @UserAccount, @Password, 
-                    @PreLaunchExecutablePath, @PreLaunchStartupDirectory, @PreLaunchParameters, @PreLaunchEnvironmentVariables, 
+                    @Name, @Description, @ExecutablePath, @StartupDirectory, @Parameters,
+                    @StartupType, @Priority, @StdoutPath, @StderrPath, @EnableRotation, @RotationSize,
+                    @EnableHealthMonitoring, @HeartbeatInterval, @MaxFailedChecks, @RecoveryAction, @MaxRestartAttempts,
+                    @EnvironmentVariables, @ServiceDependencies, @RunAsLocalSystem, @UserAccount, @Password,
+                    @PreLaunchExecutablePath, @PreLaunchStartupDirectory, @PreLaunchParameters, @PreLaunchEnvironmentVariables,
                     @PreLaunchStdoutPath, @PreLaunchStderrPath, @PreLaunchTimeoutSeconds, @PreLaunchRetryAttempts, @PreLaunchIgnoreFailure,
                     @FailureProgramPath, @FailureProgramStartupDirectory, @FailureProgramParameters,
                     @PostLaunchExecutablePath, @PostLaunchStartupDirectory, @PostLaunchParameters, @Pid, @EnableDebugLogs, @DisplayName, @MaxRotations,
                     @EnableDateRotation, @DateRotationType, @StartTimeout, @StopTimeout,
                     @PreStopExecutablePath, @PreStopStartupDirectory, @PreStopParameters, @PreStopTimeoutSeconds, @PreStopLogAsError,
-                    @PostStopExecutablePath, @PostStopStartupDirectory, @PostStopParameters, @UseLocalTimeForRotation
+                    @PostStopExecutablePath, @PostStopStartupDirectory, @PostStopParameters, @UseLocalTimeForRotation,
+                    @PreviousStopTimeout, @ActiveStdoutPath, @ActiveStderrPath
                 )
                 ON CONFLICT(LOWER(Name)) DO UPDATE SET
                     Description = excluded.Description,
@@ -443,7 +447,10 @@ namespace Servy.Infrastructure.Data
                     PostStopExecutablePath = excluded.PostStopExecutablePath,
                     PostStopStartupDirectory = excluded.PostStopStartupDirectory,
                     PostStopParameters = excluded.PostStopParameters,
-                    UseLocalTimeForRotation = excluded.UseLocalTimeForRotation;";
+                    UseLocalTimeForRotation = excluded.UseLocalTimeForRotation,
+                    PreviousStopTimeout = COALESCE(excluded.PreviousStopTimeout, Services.PreviousStopTimeout),
+                    ActiveStdoutPath = excluded.ActiveStdoutPath,
+                    ActiveStderrPath = excluded.ActiveStderrPath;";
 
             // Standard Dapper collection execution. Returning affected row count.
             return await _dapper.ExecuteAsync(sql, encryptedServices);


### PR DESCRIPTION
## Summary

- **ServiceRepository.cs** — `AddAsync` and `UpsertBatchAsync` were missing `PreviousStopTimeout`, `ActiveStdoutPath`, and `ActiveStderrPath` columns that `UpsertAsync` already includes. Fresh inserts left these null. (Closes #455)
- **ServiceManager.cs** — `Marshal.GetLastWin32Error()` was called after `IsServiceInstalled()`, which overwrites the error code via its own P/Invoke calls. Now captured immediately after `CreateService`. (Closes #456)
- **ServiceInstallValidator.cs** — `RotationSize` and `MaxRestartAttempts` validation always failed when the CLI option was omitted (null), because `int.TryParse(null)` returns false. Added null guards to allow application defaults. (Closes #460, #461)
- **Servy.psm1** — `TrimStart('-')` on `--preLaunchTimeout` produces camelCase, but `$PSBoundParameters` keys are PascalCase. The mismatch caused `ContainsKey` to always return false, incorrectly passing integer defaults like 0. (Closes #510)

## Test plan

- [ ] Run existing unit tests to verify no regressions
- [ ] Verify `AddAsync` now persists `PreviousStopTimeout`, `ActiveStdoutPath`, `ActiveStderrPath`
- [ ] Verify `CreateService` failure reports correct Win32 error code
- [ ] Verify `--enableSizeRotation` without `--rotationSize` uses default instead of failing
- [ ] Verify `--enableHealth` without `--maxRestartAttempts` uses default instead of failing
- [ ] Verify PS module integer parameters (e.g. `PreLaunchTimeout`) are only passed when explicitly supplied

🤖 Generated with [Claude Code](https://claude.com/claude-code)