### PR TITLE
Extract magic numbers to named constants across 5 files

### DIFF
--- a/src/Servy.Core/Services/ServiceManager.cs
+++ b/src/Servy.Core/Services/ServiceManager.cs
@@ -26,6 +26,7 @@ namespace Servy.Core.Services
 
         private const int ServiceStopTimeoutSeconds = 60;
         private const int ServiceStartTimeoutSeconds = 30;
+        private const int ScmPollIntervalMs = 500;
 
         public const string LocalSystemAccount = "LocalSystem";
 
@@ -597,7 +598,7 @@ namespace Servy.Core.Services
 
                         while (sc.Status != ServiceControllerStatus.Stopped && DateTime.Now < waitUntil)
                         {
-                            await Task.Delay(500); // Poll every half-second
+                            await Task.Delay(ScmPollIntervalMs);
                             sc.Refresh();
                         }
                     }

--- a/src/Servy.Manager/Utils/LogTailer.cs
+++ b/src/Servy.Manager/Utils/LogTailer.cs
@@ -18,6 +18,16 @@ namespace Servy.Manager.Utils
         private const int MaxSafeLines = 10_000;
 
         /// <summary>
+        /// Number of lines to accumulate before flushing a batch to the UI.
+        /// </summary>
+        private const int LogBatchFlushThreshold = 500;
+
+        /// <summary>
+        /// Delay in milliseconds before retrying after a file-access error (e.g. rotation).
+        /// </summary>
+        private const int FileRetryDelayMs = 500;
+
+        /// <summary>
         /// Delegate for handling a batch of new log lines.
         /// </summary>
         /// <param name="lines">The list of newly discovered log lines.</param>
@@ -67,7 +77,7 @@ namespace Servy.Manager.Utils
                     catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
                     {
                         // The file was likely rotated or deleted between File.Exists and here
-                        await Task.Delay(500, token);
+                        await Task.Delay(FileRetryDelayMs, token);
                         continue;
                     }
                     catch (IOException)
@@ -102,7 +112,7 @@ namespace Servy.Manager.Utils
                                 while ((line = await reader.ReadLineAsync()) != null)
                                 {
                                     batch.Add(new LogLine(line, type));
-                                    if (batch.Count >= 500)
+                                    if (batch.Count >= LogBatchFlushThreshold)
                                     {
                                         OnNewLines?.Invoke(batch);
                                         batch = new List<LogLine>();

--- a/src/Servy.Manager/ViewModels/ConsoleViewModel.cs
+++ b/src/Servy.Manager/ViewModels/ConsoleViewModel.cs
@@ -25,6 +25,11 @@ namespace Servy.Manager.ViewModels
     /// </summary>
     public class ConsoleViewModel : ViewModelBase
     {
+        /// <summary>
+        /// Delay in milliseconds to debounce search keystrokes before filtering.
+        /// </summary>
+        private const int SearchDebounceDelayMs = 300;
+
         #region Fields
 
         private readonly IServiceRepository _serviceRepository;
@@ -254,7 +259,7 @@ namespace Servy.Manager.ViewModels
             try
             {
                 // Wait for the user to stop typing
-                await Task.Delay(300, token);
+                await Task.Delay(SearchDebounceDelayMs, token);
 
                 // Return to the UI thread to refresh the View
                 await Application.Current.Dispatcher.InvokeAsync(() =>

--- a/src/Servy.Manager/ViewModels/MainViewModel.cs
+++ b/src/Servy.Manager/ViewModels/MainViewModel.cs
@@ -27,6 +27,12 @@ namespace Servy.Manager.ViewModels
     /// </summary>
     public class MainViewModel : INotifyPropertyChanged
     {
+        /// <summary>
+        /// Maximum number of concurrent SCM operations during bulk start/stop/restart.
+        /// Caps at this value to prevent SCM saturation regardless of core count.
+        /// </summary>
+        private const int MaxBulkOperationParallelism = 8;
+
         #region Private Fields
 
         private readonly IServiceManager _serviceManager;
@@ -755,7 +761,7 @@ namespace Servy.Manager.ViewModels
                 // 3. Dispatch all operations concurrently: Scale based on hardware
                 // Use a factor of 2 to keep the pipeline full during I/O wait times, 
                 // but cap it at a reasonable limit (e.g., 8) to prevent SCM saturation.
-                int maxDegreeOfParallelism = Math.Min(Environment.ProcessorCount * 2, 8);
+                int maxDegreeOfParallelism = Math.Min(Environment.ProcessorCount * 2, MaxBulkOperationParallelism);
 
                 using (var throttler = new SemaphoreSlim(maxDegreeOfParallelism))
                 {

--- a/src/Servy.Service/Service.cs
+++ b/src/Servy.Service/Service.cs
@@ -105,6 +105,12 @@ namespace Servy.Service
         private const int DefaultScmAdditionalTimeMs = 15_000;
 
         /// <summary>
+        /// Minimum StartTimeout (in seconds) before requesting additional SCM time.
+        /// Below this threshold the default SCM timeout is sufficient.
+        /// </summary>
+        private const int ScmStartupRequestThresholdSeconds = 20;
+
+        /// <summary>
         /// The service can perform cleanup tasks during a system shutdown. 
         /// Setting this flag in the 'acceptedCommands' bitmask enables the service 
         /// to receive the SERVICE_CONTROL_PRESHUTDOWN notification.
@@ -602,7 +608,7 @@ namespace Servy.Service
                 _maxRestartAttempts = options.MaxRestartAttempts;
 
                 // Request timeout for startup to accommodate slow process
-                if (_options.StartTimeout > 20) // Use a lower threshold to be safe
+                if (_options.StartTimeout > ScmStartupRequestThresholdSeconds)
                 {
                     _serviceHelper.RequestAdditionalTime(this, (_options.StartTimeout + 10) * 1000, _logger!);
                 }


### PR DESCRIPTION
## Summary

- **Service.cs** — `20` → `ScmStartupRequestThresholdSeconds` (Closes #521)
- **LogTailer.cs** — `500` → `LogBatchFlushThreshold` and `FileRetryDelayMs`
- **ConsoleViewModel.cs** — `300` → `SearchDebounceDelayMs`
- **ServiceManager.cs** — `500` → `ScmPollIntervalMs`
- **MainViewModel.cs** — `8` → `MaxBulkOperationParallelism`

`ResourceHelper.cs` already had `DeltaMinutes = 20` and `ServiceManager.cs` already had `ServiceStopTimeoutSeconds`/`ServiceStartTimeoutSeconds`, so those were already addressed.

Closes #521, #522

## Test plan

- [ ] Run existing unit tests to verify no regressions
- [ ] Verify no behavioral changes — all values are identical to the previous literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)