### PR TITLE
Fix 3 improvements: monotonic timeout, WaitForExit flush, encoding preservation

### DIFF
--- a/bump-version.ps1
+++ b/bump-version.ps1
@@ -44,19 +44,41 @@ Write-Host "Updating Servy version to $Version..."
 # Base directory of the script
 $baseDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
+# Helper: read file preserving encoding, apply transform, write back with same encoding
+function Update-FilePreservingEncoding {
+    param(
+        [string]$Path,
+        [scriptblock]$Transform
+    )
+    $stream = [System.IO.File]::Open($Path, 'Open', 'Read')
+    try {
+        $reader = New-Object System.IO.StreamReader($stream, $true)
+        $content = $reader.ReadToEnd()
+        $encoding = $reader.CurrentEncoding
+    }
+    finally {
+        $reader.Close()
+        $stream.Close()
+    }
+    $content = & $Transform $content
+    $bytes = $encoding.GetBytes($content)
+    [System.IO.File]::WriteAllBytes($Path, $bytes)
+}
+
 # -----------------------------
 # 1. Update setup\publish.ps1
 # -----------------------------
 $publishPath = Join-Path $baseDir "setup\publish.ps1"
 if (-Not (Test-Path $publishPath)) { Write-Error "File not found: $publishPath"; exit 1 }
 
-$content = [System.IO.File]::ReadAllText($publishPath)
-$content = [regex]::Replace(
-    $content,
-    '(\[string\]\$Version\s*=\s*")[^"]*(")',
-    { param($m) "$($m.Groups[1].Value)$Version$($m.Groups[2].Value)" }
-)
-[System.IO.File]::WriteAllText($publishPath, $content)
+Update-FilePreservingEncoding -Path $publishPath -Transform {
+    param($c)
+    [regex]::Replace(
+        $c,
+        '(\[string\]\$Version\s*=\s*")[^"]*(")',
+        { param($m) "$($m.Groups[1].Value)$Version$($m.Groups[2].Value)" }
+    )
+}
 Write-Host "Updated $publishPath"
 
 # -----------------------------
@@ -65,13 +87,14 @@ Write-Host "Updated $publishPath"
 $appConfigPath = Join-Path $baseDir "src\Servy.Core\Config\AppConfig.cs"
 if (-Not (Test-Path $appConfigPath)) { Write-Error "File not found: $appConfigPath"; exit 1 }
 
-$content = [System.IO.File]::ReadAllText($appConfigPath)
-$content = [regex]::Replace(
-    $content,
-    '(public static readonly string Version\s*=\s*")[^"]*(";)',
-    { param($m) "$($m.Groups[1].Value)$Version$($m.Groups[2].Value)" }
-)
-[System.IO.File]::WriteAllText($appConfigPath, $content)
+Update-FilePreservingEncoding -Path $appConfigPath -Transform {
+    param($c)
+    [regex]::Replace(
+        $c,
+        '(public static readonly string Version\s*=\s*")[^"]*(";)',
+        { param($m) "$($m.Groups[1].Value)$Version$($m.Groups[2].Value)" }
+    )
+}
 Write-Host "Updated $appConfigPath"
 
 # -----------------------------
@@ -79,30 +102,24 @@ Write-Host "Updated $appConfigPath"
 # -----------------------------
 Get-ChildItem -Path $baseDir -Recurse -Filter *.csproj | ForEach-Object {
     $csproj = $_.FullName
-    $content = [System.IO.File]::ReadAllText($csproj)
-
-    # Update <Version>
-    $content = [regex]::Replace(
-        $content,
-        '(<Version>)[^<]*(</Version>)',
-        { param($m) "$($m.Groups[1].Value)$fullVersion$($m.Groups[2].Value)" }
-    )
-
-    # Update <FileVersion>
-    $content = [regex]::Replace(
-        $content,
-        '(<FileVersion>)[^<]*(</FileVersion>)',
-        { param($m) "$($m.Groups[1].Value)$fileVersion$($m.Groups[2].Value)" }
-    )
-
-    # Update <AssemblyVersion>
-    $content = [regex]::Replace(
-        $content,
-        '(<AssemblyVersion>)[^<]*(</AssemblyVersion>)',
-        { param($m) "$($m.Groups[1].Value)$fileVersion$($m.Groups[2].Value)" }
-    )
-
-    [System.IO.File]::WriteAllText($csproj, $content)
+    Update-FilePreservingEncoding -Path $csproj -Transform {
+        param($c)
+        $c = [regex]::Replace(
+            $c,
+            '(<Version>)[^<]*(</Version>)',
+            { param($m) "$($m.Groups[1].Value)$fullVersion$($m.Groups[2].Value)" }
+        )
+        $c = [regex]::Replace(
+            $c,
+            '(<FileVersion>)[^<]*(</FileVersion>)',
+            { param($m) "$($m.Groups[1].Value)$fileVersion$($m.Groups[2].Value)" }
+        )
+        [regex]::Replace(
+            $c,
+            '(<AssemblyVersion>)[^<]*(</AssemblyVersion>)',
+            { param($m) "$($m.Groups[1].Value)$fileVersion$($m.Groups[2].Value)" }
+        )
+    }
     Write-Host "Updated $csproj"
 }
 
@@ -112,13 +129,14 @@ Get-ChildItem -Path $baseDir -Recurse -Filter *.csproj | ForEach-Object {
 $psd1Path = Join-Path $baseDir "src\Servy.CLI\Servy.psd1"
 if (-Not (Test-Path $psd1Path)) { Write-Error "File not found: $psd1Path"; exit 1 }
 
-$content = [System.IO.File]::ReadAllText($psd1Path)
-$content = [regex]::Replace(
-    $content,
-    "(ModuleVersion\s*=\s*')[^']*(')",
-    { param($m) "$($m.Groups[1].Value)$fullVersion$($m.Groups[2].Value)" }
-)
-[System.IO.File]::WriteAllText($psd1Path, $content)
+Update-FilePreservingEncoding -Path $psd1Path -Transform {
+    param($c)
+    [regex]::Replace(
+        $c,
+        "(ModuleVersion\s*=\s*')[^']*(')",
+        { param($m) "$($m.Groups[1].Value)$fullVersion$($m.Groups[2].Value)" }
+    )
+}
 Write-Host "Updated $psd1Path"
 
 Write-Host "All version updates complete."

--- a/src/Servy.CLI/Servy.psm1
+++ b/src/Servy.CLI/Servy.psm1
@@ -403,7 +403,7 @@ function Invoke-ServyCli {
   finally {
     if ($null -ne $process) {
         try { $process.CancelErrorRead() } catch {}
-        Start-Sleep -Milliseconds 50  # let in-flight events drain
+        try { $process.WaitForExit() } catch {}  # flush async stdout/stderr
     }    
 
     # Capture stderr BEFORE cleanup

--- a/src/Servy.Core/Services/ServiceManager.cs
+++ b/src/Servy.Core/Services/ServiceManager.cs
@@ -8,6 +8,7 @@ using Servy.Core.Logging;
 using Servy.Core.Native;
 using Servy.Core.ServiceDependencies;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.ServiceProcess;
@@ -593,11 +594,11 @@ namespace Servy.Core.Services
                     using (var sc = _controllerFactory(serviceName))
                     {
                         sc.Refresh();
-                        DateTime waitUntil = DateTime.Now.AddSeconds(ServiceStopTimeoutSeconds);
+                        var sw = Stopwatch.StartNew();
 
-                        while (sc.Status != ServiceControllerStatus.Stopped && DateTime.Now < waitUntil)
+                        while (sc.Status != ServiceControllerStatus.Stopped && sw.Elapsed.TotalSeconds < ServiceStopTimeoutSeconds)
                         {
-                            await Task.Delay(500); // Poll every half-second
+                            await Task.Delay(ScmPollIntervalMs);
                             sc.Refresh();
                         }
                     }


### PR DESCRIPTION
## Summary

- **ServiceManager.cs** — Replace `DateTime.Now` with `Stopwatch` for monotonic elapsed-time measurement during uninstall polling, avoiding issues with DST transitions and system clock adjustments. (Closes #498)
- **Servy.psm1** — Replace `Start-Sleep -Milliseconds 50` with `$process.WaitForExit()` (zero-arg overload) to properly flush async stdout/stderr. This pattern was already used for the `$killed` path in the same function. (Closes #501)
- **bump-version.ps1** — Detect and preserve original file encoding instead of using `WriteAllText` which adds UTF-8 BOM on .NET Framework PowerShell 5.1. Consistent with `bump-runtime.ps1` which already does this correctly. (Closes #502)

## Test plan

- [ ] Run existing unit tests to verify no regressions
- [ ] Verify uninstall timeout still works correctly (behavioral equivalent)
- [ ] Verify PS module stderr capture still works after replacing sleep with WaitForExit
- [ ] Run `bump-version.ps1` and verify output files don't gain a UTF-8 BOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)