### PR TITLE
fix: rename test method Correcty → Correctly in LogTailerTests.cs

### DIFF
--- a/tests/Servy.Manager.UnitTests/Utils/LogTailerTests.cs
+++ b/tests/Servy.Manager.UnitTests/Utils/LogTailerTests.cs
@@ -131,7 +131,7 @@ namespace Servy.Manager.UnitTests.Utils
         }
 
         [Fact]
-        public async Task GetHistoryAsync_ShouldHandleSyntheticTimestampsCorrecty()
+        public async Task GetHistoryAsync_ShouldHandleSyntheticTimestampsCorrectly()
         {
             // Arrange
             var tailer = new LogTailer();


### PR DESCRIPTION
**Issue:** #2397

**Fix:** Renamed test method from `GetHistoryAsync_ShouldHandleSyntheticTimestampsCorrecty` to `GetHistoryAsync_ShouldHandleSyntheticTimestampsCorrectly` in `tests/Servy.Manager.UnitTests/Utils/LogTailerTests.cs` line 134.

Test names are the human-readable spec of behavior and show up verbatim in test runner output and CI reports, so the misspelling is visible noise.