### PR TITLE
fix(choco): correct inverted porcelain check and fix git git pull typo

### DIFF
--- a/.github/workflows/choco.yml
+++ b/.github/workflows/choco.yml
@@ -98,7 +98,7 @@ jobs:
           git add setup/choco/servy/*
            
           # Check if there is actually anything to commit
-          if ((git status --porcelain) -ne '') {
+          if ((git status --porcelain) -eq '') {
               Write-Host "No changes to commit. Skipping push."
               exit 0
           }
@@ -118,7 +118,7 @@ jobs:
                   Write-Host "Attempting to push (Attempt $($retryCount + 1))..."
          
                   # 2. Pull latest changes
-                  git git pull --rebase=merges --autostash origin main
+                  git pull --rebase=merges --autostash origin main
                   if ($LASTEXITCODE -ne 0) { 
                       throw "git pull failed with exit code $LASTEXITCODE" 
                   }


### PR DESCRIPTION
## Summary

Two independent bugs in `.github/workflows/choco.yml` — step **'Commit and Push (with Retry)'**:

### Bug 1 — inverted 'nothing to commit' check (line 100)
```powershell
# Before (WRONG): skips push when changes EXIST
if ((git status --porcelain) -ne '') {

# After (CORRECT): skips push when no changes
if ((git status --porcelain) -eq '') {
```
`git status --porcelain` is non-empty when there ARE staged changes. The original condition was backwards — it was skipping the push when changes existed instead of when there were none.

### Bug 2 — 'git git pull' typo (line 121)
```powershell
# Before
git git pull --rebase=merges --autostash origin main

# After
git pull --rebase=merges --autostash origin main
```

## Fixes
Fixes #2576