### PR TITLE
fix: add stale-selection guard after GetServicePidAsync in PerformanceViewModel.OnTickAsync

### DIFF
--- a/src/Servy.Manager/ViewModels/PerformanceViewModel.cs
+++ b/src/Servy.Manager/ViewModels/PerformanceViewModel.cs
@@ -225,6 +225,8 @@ namespace Servy.Manager.ViewModels
             _hadSelectedService = true;
 
             var currentPid = await _serviceRepository.GetServicePidAsync(currentSelection.Name, token);
+            // Drop this tick if the user switched services while we were awaiting the DB call.
+            if (!ReferenceEquals(currentSelection, _selectedService) || token.IsCancellationRequested) return;
 
             if (!currentPid.HasValue)
             {


### PR DESCRIPTION
## Summary

Fixes a race condition in  where switching services mid-await causes stale data to be written to shared UI controls.

## Bug

After the  DB call, there was **no stale-selection guard**. If the user switched services while the await was in-flight:

-  wrote the **previous** service's PID into the shared label
-  cleared the graph collections for the **newly-selected** service

The stale value remained visible until the next tick (~).

## Fix

Added the same post-await guard used by sibling ViewModels:



## Consistency

This matches the pattern already used in:
-  (line ~264): 
-  (line ~201): 

The guard was previously added to those ViewModels in #1892 but was never applied to .

## Testing

1. Select a service with a known PID (e.g. PID 1234)
2. While watching the PID label, quickly switch to a different service
3. Before fix: PID label briefly shows 1234 after switching
4. After fix: PID label is cleared/updated correctly on first tick after switch

Fixes [#2702](https://github.com/aelassas/servy/issues/2702).
