### PR TITLE
Fix ProcessLauncher test method typo

### DIFF
--- a/tests/Servy.Service.IntegrationTests/ProcessManagement/ProcessLauncherIntegrationTests.cs
+++ b/tests/Servy.Service.IntegrationTests/ProcessManagement/ProcessLauncherIntegrationTests.cs
@@ -260,7 +260,7 @@ namespace Servy.Service.IntegrationTests.ProcessManagement
         }
 
         [Fact]
-        public void ApplyLanguageFixes_JavaWithExistingEncodingProperty_DoesNotOverwiteArguments()
+        public void ApplyLanguageFixes_JavaWithExistingEncodingProperty_DoesNotOverwriteArguments()
         {
             var psi = new ProcessStartInfo { FileName = "java.exe", Arguments = "-Dfile.encoding=ISO-8859-1 -jar target.jar" };
             ProcessLauncher.ApplyLanguageFixes(psi);


### PR DESCRIPTION
Fixes #2965.

## Summary
- Renamed `ApplyLanguageFixes_JavaWithExistingEncodingProperty_DoesNotOverwiteArguments` to `ApplyLanguageFixes_JavaWithExistingEncodingProperty_DoesNotOverwriteArguments`.
- Left the test behavior unchanged.

## Validation
- `rg -n "DoesNotOverwiteArguments|DoesNotOverwriteArguments|Overwite|Overwrite" tests/Servy.Service.IntegrationTests/ProcessManagement/ProcessLauncherIntegrationTests.cs`
- `git diff --check`

Blocked locally:
- `dotnet test tests/Servy.Service.IntegrationTests/Servy.Service.IntegrationTests.csproj --filter ApplyLanguageFixes_JavaWithExistingEncodingProperty_DoesNotOverwriteArguments --no-restore` could not run because `dotnet` is not installed in this environment.