### PR TITLE
docs: fix MaxRotations XML summary typo

### DIFF
--- a/src/Servy.Core/Services/InstallServiceOptions.cs
+++ b/src/Servy.Core/Services/InstallServiceOptions.cs
@@ -1,4 +1,4 @@
-using Servy.Core.Config;
+﻿using Servy.Core.Config;
 using Servy.Core.Enums;
 
 namespace Servy.Core.Services

--- a/src/Servy.Core/Services/InstallServiceOptions.cs
+++ b/src/Servy.Core/Services/InstallServiceOptions.cs
@@ -1,4 +1,4 @@
-﻿using Servy.Core.Config;
+using Servy.Core.Config;
 using Servy.Core.Enums;
 
 namespace Servy.Core.Services
@@ -134,7 +134,7 @@ namespace Servy.Core.Services
         /// <summary>The Display Name of the service, shown in the Windows Services management console (<c>services.msc</c>).</summary>
         public string? DisplayName { get; set; }
 
-        /// <summary>The maximum number of rotated log file to keep. Set to 0 for unlimited.</summary>
+        /// <summary>The maximum number of rotated log files to keep. Set to 0 for unlimited.</summary>
         public int MaxRotations { get; set; } = AppConfig.DefaultMaxRotations;
 
         /// <summary>Enables rotation based on the date interval specified by <see cref="DateRotationType"/>.</summary>


### PR DESCRIPTION
## Summary
- pluralizes the `MaxRotations` XML summary so it says "rotated log files" rather than "rotated log file"

Fixes #3247.

## Validation
- `rg -n "rotated log file|rotated log files|MaxRotations" src/Servy.Core/Services/InstallServiceOptions.cs`
- `python3` source assertion for the corrected summary text
- `git diff --check origin/main...HEAD`

I could not run the .NET test suite locally because `dotnet` is not installed in this environment (`dotnet --info` returned `command not found`).