### PR TITLE
tests: fix environment test name typo

### DIFF
--- a/tests/Servy.Core.UnitTests/Helpers/StringHelperTests.cs
+++ b/tests/Servy.Core.UnitTests/Helpers/StringHelperTests.cs
@@ -123,7 +123,7 @@ namespace Servy.Core.UnitTests.Helpers
         }
 
         [Fact]
-        public void FormatEnvirnomentVariables_ShouldEscapeSpecialCharactersCorrectly()
+        public void FormatEnvironmentVariables_ShouldEscapeSpecialCharactersCorrectly()
         {
             // Arrange
             // Each variable tests one or more escape sequences:


### PR DESCRIPTION
Closes #2455.

## Summary
- Fix the typo in `FormatEnvironmentVariables_ShouldEscapeSpecialCharactersCorrectly` test method name.

## Verification
- `git diff --check`
- `rg -n 'FormatEnvirnomentVariables' tests/Servy.Core.UnitTests/Helpers/StringHelperTests.cs || true`